### PR TITLE
fix: prevent cp949 encoding crash on Windows scheduled execution

### DIFF
--- a/main.py
+++ b/main.py
@@ -672,6 +672,14 @@ def check_environment():
 # ── 메인 ──
 
 def main():
+    # Windows 스케줄러(cmd /c) 등 non-UTF-8 환경에서 이모지 출력 크래시 방지
+    if sys.stdout and hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+            sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
     parser = argparse.ArgumentParser(description="Claw-Log: 커리어 자동 기록 도구")
     parser.add_argument("--version", action="version", version=f"claw-log {__version__}")
     parser.add_argument("--reset", action="store_true", help="설정 초기화 및 마법사 재실행")

--- a/scheduler.py
+++ b/scheduler.py
@@ -163,7 +163,8 @@ def install_schedule(schedule_time="23:30"):
     
     cwd = os.getcwd()
     log_file_path = os.path.join(cwd, SCHEDULER_LOG)
-    cmd_str = f"cd {cwd} && {python_executable} -m claw_log.main >> {log_file_path} 2>&1"
+    env_prefix = "set PYTHONIOENCODING=utf-8 && " if platform.system() == "Windows" else ""
+    cmd_str = f"cd {cwd} && {env_prefix}{python_executable} -m claw_log.main >> {log_file_path} 2>&1"
     
     print(f"\n🕒 [{system}] 스케줄러 등록 작업 시작...")
     print(f"   - 실행 시각: 매일 {hour}:{minute}")


### PR DESCRIPTION
## Summary
- Windows 작업 스케줄러(schtasks)가 `cmd /c`로 실행 시 stdout이 cp949 인코딩을 사용하여 이모지 출력에서 `UnicodeEncodeError` 발생으로 매번 즉시 크래시하는 버그 수정
- `main.py`: `main()` 시작 시 `sys.stdout`/`sys.stderr`를 UTF-8로 reconfigure
- `scheduler.py`: Windows schtasks 명령어에 `PYTHONIOENCODING=utf-8` 환경변수 추가 (이중 안전장치)

## Test plan
- [x] `cmd /c` 환경에서 `PYTHONIOENCODING=utf-8` 적용 후 이모지 출력 정상 확인
- [x] `claw-log --status` 정상 동작 확인
- [ ] 스케줄 재등록 후 예약 시각에 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)