### PR TITLE
feat: Notion integration for career log sync

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ except (ImportError, PackageNotFoundError):
     __version__ = "unknown"
 
 from claw_log.engine import GeminiSummarizer, OpenAISummarizer, CodexOAuthSummarizer
-from claw_log.storage import prepend_to_log_file, read_recent_logs, LOG_FILENAME, LOG_FILE
+from claw_log.storage import prepend_to_log_file, read_recent_logs, save_log, LOG_FILENAME, LOG_FILE
 from claw_log.scheduler import install_schedule, show_schedule, remove_schedule, get_schedule_summary
 from claw_log.state import load_state, save_state, get_last_hash, acquire_run_lock, release_run_lock
 from claw_log.git_collector import (
@@ -413,6 +413,124 @@ def change_engine():
         print(f"✅ 엔진 변경 완료: {llm_type.upper()}")
 
 
+# ── Notion 설정 ──
+
+def setup_notion():
+    """Notion 연동 설정. 토큰 입력 → 페이지 검색 → 선택 → DB 생성."""
+    import questionary
+    from claw_log.notion import NotionClient, NotionAPIError
+
+    print("\n☁️  Notion 연동 설정\n")
+
+    # Step 1: 토큰 생성 안내
+    print("   📝 Notion Integration을 먼저 만들어주세요.")
+    print("      1. https://www.notion.so/my-integrations 접속")
+    print("      2. \"+ 새 Integration\" 클릭 → 이름 입력 → 생성")
+    print("      3. 생성된 Token(secret_...)을 복사\n")
+
+    # Step 2: 토큰 입력 + 검증
+    while True:
+        token = safe_input("   👉 Notion Token: ", "").strip()
+        if not token:
+            print("   ⚠️  토큰이 입력되지 않았습니다.")
+            return False
+
+        print("   🔍 토큰 검증 중...", end=" ")
+        client = NotionClient(token)
+        if client.validate_token():
+            print("✅")
+            break
+        else:
+            print("❌ 유효하지 않은 토큰입니다. 다시 입력해주세요.")
+
+    # Step 3: 연결된 페이지 검색
+    while True:
+        print("\n   🔍 접근 가능한 페이지를 검색 중...")
+        try:
+            pages = client.search_pages()
+        except NotionAPIError as e:
+            print(f"   ❌ 페이지 검색 실패: {e}")
+            return False
+
+        if pages:
+            break
+
+        print("   ⚠️  Integration에 연결된 페이지가 없습니다.")
+        print("      👉 Notion 앱에서 원하는 페이지 열기 → ⋯ → 연결 → Integration 선택")
+        retry = safe_input("      👉 연결 후 Enter를 눌러 다시 검색하세요. (q=취소): ", "q").strip()
+        if retry.lower() == "q":
+            print("   ⏭️  Notion 설정을 건너뜁니다.")
+            return False
+
+    # Step 4: 페이지 선택
+    choices = []
+    for p in pages:
+        label = f"{p['title']:<30s}  {p['url']}"
+        choices.append(questionary.Choice(title=label, value=p["id"]))
+
+    print(f"\n   🔍 {len(pages)}개 페이지 발견")
+    selected_page_id = questionary.select(
+        "   Career Logs를 저장할 페이지를 선택하세요:",
+        choices=choices,
+        instruction="(↑↓ 이동, Enter 확정)",
+    ).ask()
+
+    if not selected_page_id:
+        print("   ⚠️  선택이 취소되었습니다.")
+        return False
+
+    # Step 5: DB 생성
+    print("\n   📦 Career Logs Database 생성 중...", end=" ")
+    try:
+        db_id = client.ensure_database(selected_page_id)
+        print("✅")
+    except NotionAPIError as e:
+        print(f"❌\n   {e}")
+        if e.hint:
+            print(f"   💡 {e.hint}")
+        return False
+
+    # .env 저장
+    env_data = _read_env_data()
+    env_data["NOTION_TOKEN"] = token
+    env_data["NOTION_PAGE_ID"] = selected_page_id
+    env_data["NOTION_DB_ID"] = db_id
+    if _save_env_data(env_data):
+        print(f"\n   ✅ Notion 연동 완료!")
+        return True
+    return False
+
+
+def disconnect_notion():
+    """Notion 연동 해제 (.env에서 키 제거)."""
+    load_dotenv(ENV_PATH, override=True)
+    env_data = _read_env_data()
+    removed = False
+    for key in ("NOTION_TOKEN", "NOTION_PAGE_ID", "NOTION_DB_ID"):
+        if key in env_data:
+            del env_data[key]
+            removed = True
+    if removed:
+        _save_env_data(env_data)
+        print("✅ Notion 연동이 해제되었습니다.")
+    else:
+        print("ℹ️  Notion 연동 설정이 없습니다.")
+
+
+# ── Notion 클라이언트 초기화 (공용) ──
+
+def _init_notion():
+    """환경변수에서 Notion 설정을 읽어 클라이언트를 초기화."""
+    token = os.getenv("NOTION_TOKEN", "")
+    page_id = os.getenv("NOTION_PAGE_ID", "")
+    db_id = os.getenv("NOTION_DB_ID", "")
+    if not token:
+        return None, None, None
+    from claw_log.notion import NotionClient
+    client = NotionClient(token)
+    return client, db_id, page_id
+
+
 # ── 마법사 ──
 
 def run_wizard():
@@ -470,6 +588,16 @@ def run_wizard():
             print("   ⚠️ HH:MM 형식이 아닙니다. 스케줄 등록을 건너뜁니다.")
     else:
         print("   ⏭️  자동 기록 스케줄을 건너뜁니다.")
+
+    # 5. Notion 연동 (선택사항)
+    print("\n5️⃣  Notion 연동을 설정할까요? (선택사항)")
+    print("   [1] 설정하기")
+    print("   [2] 나중에 (건너뛰기)")
+    notion_choice = safe_input("   👉 선택 (1/2): ", "2").strip()
+    if notion_choice == "1":
+        setup_notion()
+    else:
+        print("   ⏭️  Notion 연동을 건너뜁니다.")
 
 
 # ── 배칭 파이프라인 ──
@@ -651,15 +779,43 @@ def run_batched_summarization(target_paths, summarizer, days):
 
 
 def _save_all_summaries(summaries, days):
-    """모든 배치 요약을 합쳐서 로그 파일에 1회 저장."""
+    """모든 배치 요약을 합쳐서 저장 (Notion + 로컬)."""
     combined = "\n\n".join(summaries)
     if days > 0:
         start_date = (datetime.date.today() - datetime.timedelta(days=days)).strftime("%Y-%m-%d")
         end_date = datetime.date.today().strftime("%Y-%m-%d")
-        saved_file = prepend_to_log_file(combined, date_label=f"{start_date} ~ {end_date}")
+        date_label = f"{start_date} ~ {end_date}"
     else:
-        saved_file = prepend_to_log_file(combined)
-    print(f"\n기록 완료: {saved_file}")
+        date_label = None
+
+    notion_client, notion_db_id, notion_page_id = _init_notion()
+
+    # DB ID 확보 (Notion 설정이 있는 경우)
+    if notion_client and notion_page_id and not notion_db_id:
+        try:
+            from claw_log.notion import NotionAPIError
+            notion_db_id = notion_client.ensure_database(notion_page_id)
+            # DB ID 캐싱
+            env_data = _read_env_data()
+            env_data["NOTION_DB_ID"] = notion_db_id
+            _save_env_data(env_data)
+        except Exception:
+            pass
+
+    result = save_log(
+        combined,
+        date_label=date_label,
+        notion_client=notion_client,
+        notion_db_id=notion_db_id,
+        notion_page_id=notion_page_id,
+    )
+
+    if result["notion"]:
+        print(f"\n☁️  Notion 저장 완료: {result['notion_url']}")
+    if result["local"]:
+        print(f"💾 로컬 저장 완료: {result['local_path']}")
+    if result.get("error"):
+        print(f"⚠️  {result['error']}")
 
 
 # ── 업데이트 확인 ──
@@ -750,6 +906,8 @@ def main():
     parser.add_argument("--serve", nargs="?", const=8080, type=int, metavar="PORT", help="로컬 웹 대시보드 (기본 포트: 8080)")
     parser.add_argument("--log-edit", action="store_true", help="커리어 로그 파일을 기본 편집기로 열기")
     parser.add_argument("--update", action="store_true", help="최신 버전 확인 및 업데이트")
+    parser.add_argument("--notion-setup", action="store_true", help="Notion 연동 설정")
+    parser.add_argument("--notion-disconnect", action="store_true", help="Notion 연동 해제")
     args = parser.parse_args()
 
     # 0. 즉시 실행 명령어 (설정 불필요)
@@ -765,6 +923,13 @@ def main():
         return
     if args.engine:
         change_engine()
+        return
+    if args.notion_setup:
+        load_dotenv(ENV_PATH, override=True)
+        setup_notion()
+        return
+    if args.notion_disconnect:
+        disconnect_notion()
         return
     if args.log_edit:
         log_path = LOG_FILE

--- a/notion.py
+++ b/notion.py
@@ -1,0 +1,376 @@
+"""
+Claw-Log Notion Module
+urllib 기반 Notion REST API 클라이언트 및 마크다운→Notion 블록 변환.
+"""
+
+import json
+import re
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+
+
+# =============================================================================
+#  예외
+# =============================================================================
+
+class NotionAPIError(Exception):
+    """Notion API 호출 실패."""
+
+    def __init__(self, status, message, hint=""):
+        self.status = status
+        self.message = message
+        self.hint = hint
+        super().__init__(f"[{status}] {message}")
+
+
+# =============================================================================
+#  NotionClient
+# =============================================================================
+
+class NotionClient:
+    BASE_URL = "https://api.notion.com/v1"
+    NOTION_VERSION = "2022-06-28"
+
+    def __init__(self, token: str):
+        self.token = token
+
+    # ── HTTP 공통 ──
+
+    def _request(self, method, endpoint, data=None) -> dict:
+        """Notion API HTTP 요청. 인증 헤더 + JSON 처리."""
+        url = f"{self.BASE_URL}{endpoint}"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Notion-Version": self.NOTION_VERSION,
+            "Content-Type": "application/json",
+        }
+        body = json.dumps(data).encode("utf-8") if data else None
+        req = Request(url, data=body, headers=headers, method=method)
+
+        try:
+            with urlopen(req, timeout=30) as resp:
+                raw = resp.read().decode("utf-8")
+                return json.loads(raw) if raw else {}
+        except HTTPError as e:
+            body_text = e.read().decode("utf-8", errors="replace")[:300]
+            status = e.code
+            if status == 401:
+                raise NotionAPIError(
+                    401, "Notion 토큰이 유효하지 않습니다.",
+                    "claw-log --notion-setup 으로 토큰을 재설정하세요.",
+                )
+            if status == 403:
+                raise NotionAPIError(
+                    403, "페이지 접근 권한이 없습니다.",
+                    "Notion 앱에서 해당 페이지에 Integration을 연결해주세요.",
+                )
+            if status == 404:
+                raise NotionAPIError(
+                    404, "페이지 또는 Database를 찾을 수 없습니다.",
+                    "ID를 확인하세요.",
+                )
+            if status == 429:
+                raise NotionAPIError(429, "Notion API Rate Limit 초과.")
+            if status >= 500:
+                raise NotionAPIError(status, f"Notion 서버 오류: {body_text}")
+            raise NotionAPIError(status, f"Notion API 오류: {body_text}")
+        except URLError as e:
+            reason = str(e.reason) if hasattr(e, 'reason') else str(e)
+            raise NotionAPIError(0, f"네트워크 오류: {reason}", "인터넷 연결을 확인하세요.")
+        except (TimeoutError, OSError) as e:
+            raise NotionAPIError(0, f"Notion API 연결 실패: {e}")
+
+    # ── 토큰 검증 ──
+
+    def validate_token(self) -> bool:
+        """토큰 유효성 검증 (GET /users/me)"""
+        try:
+            self._request("GET", "/users/me")
+            return True
+        except NotionAPIError:
+            return False
+
+    # ── 페이지 검색 ──
+
+    def search_pages(self) -> list[dict]:
+        """Integration에 연결된 모든 페이지를 검색 (POST /search)."""
+        result = self._request("POST", "/search", {
+            "filter": {"value": "page", "property": "object"},
+            "sort": {"direction": "descending", "timestamp": "last_edited_time"},
+        })
+        pages = []
+        for page in result.get("results", []):
+            title = _extract_title(page)
+            pages.append({
+                "id": page["id"],
+                "title": title or "(제목 없음)",
+                "url": page.get("url", ""),
+            })
+        return pages
+
+    # ── Database 관리 ──
+
+    def create_database(self, parent_page_id: str) -> str:
+        """부모 페이지 아래에 'Career Logs' Database 생성."""
+        result = self._request("POST", "/databases", {
+            "parent": {"type": "page_id", "page_id": parent_page_id},
+            "title": [{"type": "text", "text": {"content": "Career Logs"}}],
+            "properties": {
+                "Name": {"title": {}},
+                "Date": {"date": {}},
+            },
+        })
+        return result["id"]
+
+    def find_database(self, parent_page_id: str) -> str | None:
+        """부모 페이지의 자식 블록에서 기존 Career Logs DB 검색."""
+        result = self._request("GET", f"/blocks/{parent_page_id}/children?page_size=100")
+        for block in result.get("results", []):
+            if block.get("type") == "child_database":
+                raw_title = block.get("child_database", {}).get("title", "")
+                # title은 문자열 또는 rich_text 배열일 수 있음
+                if isinstance(raw_title, str):
+                    db_title = raw_title
+                elif isinstance(raw_title, list):
+                    db_title = "".join(
+                        t.get("plain_text", "") if isinstance(t, dict) else str(t)
+                        for t in raw_title
+                    )
+                else:
+                    db_title = str(raw_title)
+                if "Career Logs" in db_title:
+                    return block["id"]
+        return None
+
+    def ensure_database(self, parent_page_id: str, database_id: str | None = None) -> str:
+        """database_id가 있으면 검증, 없으면 find→create 순으로 확보."""
+        if database_id:
+            try:
+                self._request("GET", f"/databases/{database_id}")
+                return database_id
+            except NotionAPIError:
+                pass
+        found = self.find_database(parent_page_id)
+        if found:
+            return found
+        return self.create_database(parent_page_id)
+
+    # ── 페이지 CRUD ──
+
+    def find_page_by_date(self, database_id: str, date_str: str) -> str | None:
+        """해당 날짜의 페이지가 이미 있는지 조회 (중복 방지)."""
+        result = self._request("POST", f"/databases/{database_id}/query", {
+            "filter": {
+                "property": "Date",
+                "date": {"equals": date_str},
+            },
+        })
+        results = result.get("results", [])
+        if results:
+            return results[0]["id"]
+        return None
+
+    def create_page(self, database_id: str, title: str, date_str: str, blocks: list) -> str:
+        """Database에 새 페이지 생성. 반환: page URL."""
+        # Notion API는 children을 최대 100개까지만 허용
+        first_chunk = blocks[:100]
+        remaining = blocks[100:]
+        result = self._request("POST", "/pages", {
+            "parent": {"database_id": database_id},
+            "properties": {
+                "Name": {"title": [{"text": {"content": title}}]},
+                "Date": {"date": {"start": date_str}},
+            },
+            "children": first_chunk,
+        })
+        page_id = result["id"]
+        # 나머지 blocks를 100개씩 append
+        self._append_blocks(page_id, remaining)
+        return result.get("url", "")
+
+    def update_page_content(self, page_id: str, blocks: list):
+        """기존 페이지의 내용을 교체 (같은 날짜 재실행 시)."""
+        # 1. 기존 children 전부 삭제 (pagination 처리)
+        self._delete_all_children(page_id)
+        # 2. 새 blocks 추가 (100개 단위)
+        self._append_blocks(page_id, blocks)
+
+    def _delete_all_children(self, block_id: str):
+        """블록의 모든 자식을 pagination으로 순회하며 삭제."""
+        start_cursor = None
+        while True:
+            endpoint = f"/blocks/{block_id}/children?page_size=100"
+            if start_cursor:
+                endpoint += f"&start_cursor={start_cursor}"
+            result = self._request("GET", endpoint)
+            for block in result.get("results", []):
+                try:
+                    self._request("DELETE", f"/blocks/{block['id']}")
+                except NotionAPIError:
+                    pass
+            if not result.get("has_more"):
+                break
+            start_cursor = result.get("next_cursor")
+
+    def _append_blocks(self, parent_id: str, blocks: list):
+        """blocks를 100개 단위로 분할하여 append."""
+        for i in range(0, len(blocks), 100):
+            chunk = blocks[i:i + 100]
+            self._request("PATCH", f"/blocks/{parent_id}/children", {"children": chunk})
+
+
+# =============================================================================
+#  유틸리티
+# =============================================================================
+
+def _extract_title(page: dict) -> str:
+    """Notion page 객체에서 제목 텍스트 추출."""
+    props = page.get("properties", {})
+    for prop in props.values():
+        if prop.get("type") == "title":
+            parts = prop.get("title", [])
+            return "".join(t.get("plain_text", "") for t in parts)
+    return ""
+
+
+# =============================================================================
+#  마크다운 → Notion 블록 변환
+# =============================================================================
+
+RICH_TEXT_LIMIT = 2000
+
+
+def _parse_inline(text: str) -> list[dict]:
+    """마크다운 인라인 서식을 Notion rich_text 배열로 변환."""
+    segments = []
+    # bold(**) 및 code(`) 패턴 매칭
+    pattern = re.compile(r"(\*\*(.+?)\*\*|`(.+?)`)")
+    pos = 0
+    for m in pattern.finditer(text):
+        # 매치 전 일반 텍스트
+        if m.start() > pos:
+            plain = text[pos:m.start()]
+            if plain:
+                segments.append(_rich_text(plain))
+        if m.group(2) is not None:
+            # bold
+            segments.append(_rich_text(m.group(2), bold=True))
+        elif m.group(3) is not None:
+            # code
+            segments.append(_rich_text(m.group(3), code=True))
+        pos = m.end()
+    # 나머지 일반 텍스트
+    if pos < len(text):
+        remaining = text[pos:]
+        if remaining:
+            segments.append(_rich_text(remaining))
+    if not segments:
+        segments.append(_rich_text(text))
+    return segments
+
+
+def _rich_text(content: str, bold=False, code=False) -> dict:
+    """단일 rich_text 요소 생성."""
+    annotations = {}
+    if bold:
+        annotations["bold"] = True
+    if code:
+        annotations["code"] = True
+    rt = {"type": "text", "text": {"content": content[:RICH_TEXT_LIMIT]}}
+    if annotations:
+        rt["annotations"] = annotations
+    return rt
+
+
+def _make_block(block_type: str, rich_text: list[dict]) -> dict:
+    """Notion block 객체 생성."""
+    return {"object": "block", "type": block_type, block_type: {"rich_text": rich_text}}
+
+
+def _split_long_text(rich_text_list: list[dict]) -> list[list[dict]]:
+    """rich_text가 2000자를 넘으면 분할."""
+    total = sum(len(rt["text"]["content"]) for rt in rich_text_list)
+    if total <= RICH_TEXT_LIMIT:
+        return [rich_text_list]
+    # 단순 분할: 각 요소를 2000자 단위로 쪼갬
+    chunks = []
+    current = []
+    current_len = 0
+    for rt in rich_text_list:
+        content = rt["text"]["content"]
+        while content:
+            available = RICH_TEXT_LIMIT - current_len
+            piece = content[:available]
+            content = content[available:]
+            new_rt = dict(rt)
+            new_rt["text"] = {"content": piece}
+            current.append(new_rt)
+            current_len += len(piece)
+            if current_len >= RICH_TEXT_LIMIT:
+                chunks.append(current)
+                current = []
+                current_len = 0
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def md_to_notion_blocks(markdown: str) -> list[dict]:
+    """마크다운 문자열을 Notion block 리스트로 변환."""
+    blocks = []
+    lines = markdown.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # 빈 줄 무시
+        if not stripped:
+            i += 1
+            continue
+
+        # 구분선
+        if re.match(r"^-{3,}$", stripped):
+            blocks.append({"object": "block", "type": "divider", "divider": {}})
+            i += 1
+            continue
+
+        # heading_2
+        m = re.match(r"^##\s+(.+)$", stripped)
+        if m:
+            rt = _parse_inline(m.group(1))
+            blocks.append(_make_block("heading_2", rt))
+            i += 1
+            continue
+
+        # heading_3
+        m = re.match(r"^###\s+(.+)$", stripped)
+        if m:
+            rt = _parse_inline(m.group(1))
+            blocks.append(_make_block("heading_3", rt))
+            i += 1
+            continue
+
+        # quote
+        if stripped.startswith("> "):
+            rt = _parse_inline(stripped[2:])
+            blocks.append(_make_block("quote", rt))
+            i += 1
+            continue
+
+        # bulleted list item
+        m = re.match(r"^[-*]\s+(.+)$", stripped)
+        if m:
+            rt = _parse_inline(m.group(1))
+            for chunk in _split_long_text(rt):
+                blocks.append(_make_block("bulleted_list_item", chunk))
+            i += 1
+            continue
+
+        # 일반 텍스트 → paragraph
+        rt = _parse_inline(stripped)
+        for chunk in _split_long_text(rt):
+            blocks.append(_make_block("paragraph", chunk))
+        i += 1
+
+    return blocks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claw-log-sh"
-version = "1.1.2"
+version = "1.2.0"
 description = "Automated Career Log using generative AI and Git diffs (fork of claw-log, original by Kim Woohyuck)"
 readme = "README.md"
 authors = [

--- a/server.py
+++ b/server.py
@@ -68,12 +68,22 @@ def _collect_dashboard_data():
     logs = entries if entries else []
     log_error = error
 
+    # Notion
+    notion_token = env_data.get("NOTION_TOKEN", "")
+    notion_db_id = env_data.get("NOTION_DB_ID", "")
+    notion_page_id = env_data.get("NOTION_PAGE_ID", "")
+    notion_status = {
+        "connected": bool(notion_token and notion_db_id),
+        "page_id": notion_page_id or "미설정",
+    }
+
     return {
         "settings": settings,
         "projects": projects,
         "schedule": schedule,
         "logs": logs,
         "log_error": log_error,
+        "notion": notion_status,
     }
 
 
@@ -165,6 +175,7 @@ def _render_html(data):
     schedule = data["schedule"]
     logs = data["logs"]
     log_error = data.get("log_error")
+    notion = data.get("notion", {})
 
     # 프로젝트 행
     project_rows = ""
@@ -273,6 +284,8 @@ def _render_html(data):
     <span class="value">{escape(settings['engine'])}</span>
     <span class="label">API Key</span>
     <span class="value">{escape(settings['api_key'])}</span>
+    <span class="label">Notion</span>
+    <span class="value">{'<span style="color:#155724">&#x2705; 연결됨</span>' if notion.get('connected') else '<span style="color:#666">&#x26AA; 미연결 (claw-log --notion-setup)</span>'}</span>
   </div>
 </div>
 

--- a/storage.py
+++ b/storage.py
@@ -7,6 +7,50 @@ LOG_FILENAME = "career_logs.md"
 LOG_FILE = Path.home() / ".claw-log" / LOG_FILENAME
 
 
+def save_log(summary: str, date_label: str = None, notion_client=None,
+             notion_db_id: str = None, notion_page_id: str = None) -> dict:
+    """통합 저장 함수. Notion 우선 + 로컬 백업.
+
+    Returns:
+        {"notion": bool, "local": bool,
+         "notion_url": str|None, "local_path": str|None,
+         "error": str|None}
+    """
+    result = {"notion": False, "local": False, "notion_url": None, "local_path": None, "error": None}
+
+    # Notion date는 항상 ISO 형식 (오늘 날짜)
+    notion_date = datetime.date.today().strftime("%Y-%m-%d")
+    display_label = date_label if date_label else notion_date
+
+    # Notion 저장 시도
+    if notion_client and notion_db_id:
+        try:
+            from claw_log.notion import md_to_notion_blocks
+            blocks = md_to_notion_blocks(summary)
+            title = f"Career Log - {display_label}"
+
+            # 중복 체크
+            existing_page_id = notion_client.find_page_by_date(notion_db_id, notion_date)
+            if existing_page_id:
+                notion_client.update_page_content(existing_page_id, blocks)
+                # 기존 페이지 URL 조회
+                result["notion_url"] = f"https://notion.so/{existing_page_id.replace('-', '')}"
+            else:
+                url = notion_client.create_page(notion_db_id, title, notion_date, blocks)
+                result["notion_url"] = url
+            result["notion"] = True
+        except Exception as e:
+            result["error"] = f"Notion 저장 실패: {e}"
+
+    # 로컬 저장 (항상 실행)
+    saved_path = prepend_to_log_file(summary, date_label=date_label)
+    if saved_path:
+        result["local"] = True
+        result["local_path"] = str(saved_path)
+
+    return result
+
+
 def read_recent_logs(n=5, filename=LOG_FILENAME):
     """최근 N개의 로그 엔트리를 반환합니다. 각 엔트리는 '## 📅' 헤더로 구분."""
     file_path = LOG_FILE


### PR DESCRIPTION
## Summary

- Notion API 클라이언트 (`notion.py`) 신규 추가 — urllib 기반, 외부 의존성 없음
- 마크다운→Notion 블록 변환기 구현 (heading, list, quote, divider, bold/code 인라인)
- 통합 저장 흐름: Notion 우선 저장 + 로컬 백업 (fallback 포함)
- 설정 마법사 Step 5: 토큰 입력 → 페이지 검색 → 선택 → DB 자동 생성
- CLI 옵션: `--notion-setup`, `--notion-disconnect`
- 대시보드에 Notion 연결 상태 표시
- Version bump: 1.1.2 → 1.2.0

## Changed Files

| File | Change | Description |
|------|--------|-------------|
| `notion.py` | **New** | NotionClient + md_to_notion_blocks + NotionAPIError |
| `storage.py` | Modified | `save_log()` unified save function |
| `main.py` | Modified | setup_notion(), disconnect_notion(), wizard Step 5, CLI options |
| `server.py` | Modified | Dashboard Notion status display |
| `pyproject.toml` | Modified | Version 1.1.2 → 1.2.0 |

## Code Review

GPT-5.4 Codex reviewed — 4 issues found and fixed:
1. **[HIGH]** `--days` ranged date label vs ISO Notion date separation
2. **[MED]** `find_database` title parsing (str vs rich_text list)
3. **[MED]** Block limit chunking (100) + pagination for updates
4. **[MED]** Network timeout (30s) + URLError/transport error handling

## Test plan

- [ ] `claw-log --notion-setup` → token input → validation → page search → select → DB creation
- [ ] `claw-log` → Notion Database에 오늘 날짜 페이지 생성 확인
- [ ] 같은 날 재실행 → 기존 페이지 업데이트 (중복 생성 X)
- [ ] 잘못된 토큰으로 실행 → 에러 메시지 + 로컬 fallback 확인
- [ ] `claw-log --notion-disconnect` → .env에서 키 제거
- [ ] `claw-log --serve` → 대시보드에 Notion 상태 표시
- [ ] `claw-log --reset` → 마법사에서 Notion 단계 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)