### PR TITLE
fix: --days N 재실행 시 Notion 페이지 충돌 및 로컬 저장 누락 수정

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -29,8 +29,8 @@ def save_log(summary: str, date_label: str = None, notion_client=None,
             blocks = md_to_notion_blocks(summary)
             title = f"Career Log - {display_label}"
 
-            # 중복 체크
-            existing_page_id = notion_client.find_page_by_date(notion_ds_id, notion_date)
+            # 중복 체크 — title 기반으로 --days 범위별 고유 페이지 식별
+            existing_page_id = notion_client.find_page_by_name(notion_ds_id, title)
             if existing_page_id:
                 notion_client.update_page_content(existing_page_id, blocks)
                 # 기존 페이지 URL 조회
@@ -41,6 +41,11 @@ def save_log(summary: str, date_label: str = None, notion_client=None,
             result["notion"] = True
         except Exception as e:
             result["error"] = f"Notion 저장 실패: {e}"
+
+    # 빈 summary 방어
+    if not summary.strip():
+        result["error"] = "AI 요약 결과가 비어있습니다."
+        return result
 
     # 로컬 저장 (항상 실행)
     saved_path = prepend_to_log_file(summary, date_label=date_label)


### PR DESCRIPTION
## Summary
- **Notion 중복 체크**: `find_page_by_date` → `find_page_by_name` (title 기반)으로 변경하여 `--days` 값이 다를 때 별도 Notion 페이지 생성
- **빈 summary 방어**: AI 요약 결과가 비어있을 경우 로컬 저장을 건너뛰고 에러 반환

Closes #27

## Test plan
- [ ] `--days 7` 실행 후 `--days 30` 실행 → Notion에 별도 페이지 생성 확인
- [ ] 같은 `--days N`으로 재실행 → 기존 Notion 페이지 업데이트 확인
- [ ] 일반 실행 (days=0) → 기존과 동일 동작 확인
- [ ] 빈 summary 시 에러 메시지 반환 및 로컬 파일 미변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)