### PR TITLE
feat(scheduler): WSL 환경 감지 및 Windows 작업 스케줄러 연동 (v1.3.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claw-log-sh"
-version = "1.3.1"
+version = "1.3.2"
 description = "Automated Career Log using generative AI and Git diffs (fork of claw-log, original by Kim Woohyuck)"
 readme = "README.md"
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -9,29 +9,60 @@ CRON_COMMENT = "# ClawLog Daily Schedule"
 WIN_TASK_NAME = "ClawLog_Daily"
 
 
+def _is_wsl():
+    """WSL 환경인지 감지 (결과 캐싱)."""
+    if hasattr(_is_wsl, '_cached'):
+        return _is_wsl._cached
+    if os.environ.get('WSL_DISTRO_NAME'):
+        _is_wsl._cached = True
+        return True
+    try:
+        with open('/proc/version', 'r') as f:
+            result = 'microsoft' in f.read().lower()
+            _is_wsl._cached = result
+            return result
+    except (FileNotFoundError, PermissionError):
+        _is_wsl._cached = False
+        return False
+
+
+def _get_wsl_distro_name():
+    """WSL 배포판 이름 반환. 없으면 None."""
+    return os.environ.get('WSL_DISTRO_NAME')
+
+
+def _get_platform():
+    """'windows', 'wsl', 'unix' 중 하나 반환."""
+    if platform.system() == "Windows":
+        return "windows"
+    if _is_wsl():
+        return "wsl"
+    return "unix"
+
+
 def _get_cron_info():
     """현재 crontab에서 ClawLog 스케줄 정보를 읽어옵니다."""
     try:
         result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
         if result.returncode != 0:
             return None, []
-        
+
         lines = result.stdout.splitlines()
         claw_lines = []
         for line in lines:
             if "claw_log.main" in line and not line.strip().startswith("#"):
                 claw_lines.append(line)
-        
+
         return result.stdout, claw_lines
     except Exception:
         return None, []
 
 
-def _get_win_schedule_info():
+def _get_win_schedule_info(schtasks_cmd="schtasks"):
     """Windows 작업 스케줄러에서 ClawLog 정보를 읽어옵니다."""
     try:
         result = subprocess.run(
-            ["schtasks", "/Query", "/TN", WIN_TASK_NAME, "/FO", "LIST", "/V"],
+            [schtasks_cmd, "/Query", "/TN", WIN_TASK_NAME, "/FO", "LIST", "/V"],
             capture_output=True, text=True
         )
         if result.returncode != 0:
@@ -43,10 +74,11 @@ def _get_win_schedule_info():
 
 def get_schedule_summary():
     """스케줄 정보를 문자열로 반환합니다 (--status용)."""
-    system = platform.system()
+    pf = _get_platform()
+    schtasks_cmd = "schtasks.exe" if pf == "wsl" else "schtasks"
 
-    if system == "Windows":
-        info = _get_win_schedule_info()
+    if pf in ("windows", "wsl"):
+        info = _get_win_schedule_info(schtasks_cmd)
         if info:
             for line in info.splitlines():
                 line = line.strip()
@@ -69,19 +101,20 @@ def get_schedule_summary():
 
 def show_schedule():
     """현재 등록된 스케줄 정보를 출력합니다."""
-    system = platform.system()
-    
+    pf = _get_platform()
+    schtasks_cmd = "schtasks.exe" if pf == "wsl" else "schtasks"
+
     print("\n📋 현재 Claw-Log 스케줄 정보")
     print("=" * 50)
-    
-    if system == "Windows":
-        info = _get_win_schedule_info()
+
+    if pf in ("windows", "wsl"):
+        info = _get_win_schedule_info(schtasks_cmd)
         if info:
             for line in info.splitlines():
                 line = line.strip()
-                if any(k in line for k in ["작업 이름", "Task Name", "다음 실행", "Next Run", 
-                                            "상태", "Status", "예약 유형", "Schedule Type",
-                                            "시작 시간", "Start Time", "Start Date"]):
+                if any(k in line for k in ["작업 이름", "Task Name", "다음 실행", "Next Run",
+                                           "상태", "Status", "예약 유형", "Schedule Type",
+                                           "시작 시간", "Start Time", "Start Date"]):
                     print(f"   {line}")
             print("=" * 50)
         else:
@@ -98,7 +131,7 @@ def show_schedule():
                     cwd = ""
                     if "cd " in cmd_part:
                         cwd = cmd_part.split("cd ")[1].split(" &&")[0]
-                    
+
                     print(f"   ⏰ 실행 시각: 매일 {hour.zfill(2)}:{minute.zfill(2)}")
                     if cwd:
                         print(f"   📂 실행 경로: {cwd}")
@@ -111,37 +144,40 @@ def show_schedule():
 
 def remove_schedule():
     """등록된 스케줄을 삭제합니다."""
-    system = platform.system()
-    
-    if system == "Windows":
+    pf = _get_platform()
+    schtasks_cmd = "schtasks.exe" if pf == "wsl" else "schtasks"
+
+    if pf in ("windows", "wsl"):
         try:
             subprocess.run(
-                ["schtasks", "/Delete", "/TN", WIN_TASK_NAME, "/F"],
+                [schtasks_cmd, "/Delete", "/TN", WIN_TASK_NAME, "/F"],
                 check=True
             )
             print("✅ Windows 스케줄 삭제 완료!")
         except subprocess.CalledProcessError:
             print("⚠️ 삭제할 스케줄이 없거나 실패했습니다.")
+        except FileNotFoundError:
+            print("❌ schtasks.exe를 찾을 수 없습니다. WSL interop 비활성화 가능성이 있습니다.")
     else:
         full_cron, claw_lines = _get_cron_info()
         if not claw_lines:
             print("⚠️ 삭제할 스케줄이 없습니다.")
             return
-        
+
         try:
             lines = full_cron.splitlines()
             new_lines = [
-                line for line in lines 
+                line for line in lines
                 if "claw_log.main" not in line and line.strip() != CRON_COMMENT
             ]
             new_cron = "\n".join(new_lines) + "\n"
-            
+
             process = subprocess.Popen(
-                ["crontab", "-"], stdin=subprocess.PIPE, 
+                ["crontab", "-"], stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
             _, stderr = process.communicate(input=new_cron)
-            
+
             if process.returncode == 0:
                 print("✅ Crontab 스케줄 삭제 완료!")
             else:
@@ -154,24 +190,23 @@ def install_schedule(schedule_time="23:30"):
     """
     OS별 스케줄러 등록 (사용자 지정 시각에 실행)
     """
-    system = platform.system()
+    pf = _get_platform()
     python_executable = sys.executable
-    
+
     hour, minute = schedule_time.split(":")
     hour = hour.zfill(2)
     minute = minute.zfill(2)
-    
+
     cwd = os.getcwd()
     log_file_path = os.path.join(cwd, SCHEDULER_LOG)
-    env_prefix = "set PYTHONIOENCODING=utf-8 && " if platform.system() == "Windows" else ""
-    cmd_str = f"cd {cwd} && {env_prefix}{python_executable} -m claw_log.main >> {log_file_path} 2>&1"
-    
-    print(f"\n🕒 [{system}] 스케줄러 등록 작업 시작...")
+
+    print(f"\n🕒 [{pf}] 스케줄러 등록 작업 시작...")
     print(f"   - 실행 시각: 매일 {hour}:{minute}")
     print(f"   - 실행 경로: {cwd}")
     print(f"   - 로그 파일: {log_file_path}")
 
-    if system == "Windows":
+    if pf == "windows":
+        cmd_str = f'cd /d "{cwd}" && set PYTHONIOENCODING=utf-8 && "{python_executable}" -m claw_log.main >> "{log_file_path}" 2>&1'
         win_cmd = f'cmd /c "{cmd_str}"'
         try:
             subprocess.run([
@@ -181,26 +216,46 @@ def install_schedule(schedule_time="23:30"):
             print(f"✅ Windows 작업 스케줄러에 '{WIN_TASK_NAME}' 등록 완료!")
         except subprocess.CalledProcessError as e:
             print(f"❌ Windows 스케줄러 등록 실패: {e}")
+        except FileNotFoundError:
+            print("❌ schtasks를 찾을 수 없습니다.")
+    elif pf == "wsl":
+        bash_cmd = f"cd '{cwd}' && '{python_executable}' -m claw_log.main >> '{log_file_path}' 2>&1"
+        distro = _get_wsl_distro_name()
+        if distro:
+            wsl_cmd = f'wsl.exe -d {distro} -- bash -c "{bash_cmd}"'
+        else:
+            wsl_cmd = f'wsl.exe -- bash -c "{bash_cmd}"'
+        try:
+            subprocess.run([
+                "schtasks.exe", "/Create", "/SC", "DAILY", "/TN", WIN_TASK_NAME,
+                "/TR", wsl_cmd, "/ST", f"{hour}:{minute}", "/F"
+            ], check=True)
+            print(f"✅ Windows 작업 스케줄러에 '{WIN_TASK_NAME}' 등록 완료! (WSL via wsl.exe)")
+        except subprocess.CalledProcessError as e:
+            print(f"❌ Windows 스케줄러 등록 실패: {e}")
+        except FileNotFoundError:
+            print("❌ schtasks.exe를 찾을 수 없습니다. WSL interop 비활성화 가능성이 있습니다.")
     else:
+        cmd_str = f"cd '{cwd}' && '{python_executable}' -m claw_log.main >> '{log_file_path}' 2>&1"
         cron_job = f"{minute} {hour} * * * {cmd_str}"
         try:
             current_cron = subprocess.run(
                 ["crontab", "-l"], capture_output=True, text=True
             ).stdout
-            
+
             lines = current_cron.splitlines()
             new_lines = [
-                line for line in lines 
+                line for line in lines
                 if "claw_log.main" not in line and line.strip() != CRON_COMMENT
             ]
             new_cron = "\n".join(new_lines) + f"\n{CRON_COMMENT}\n{cron_job}\n"
-            
+
             process = subprocess.Popen(
                 ["crontab", "-"], stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
             _, stderr = process.communicate(input=new_cron)
-            
+
             if process.returncode == 0:
                 print(f"✅ Crontab에 스케줄 등록/업데이트 완료! (매일 {hour}:{minute})")
             else:


### PR DESCRIPTION
## Summary
- WSL 환경에서 crontab 대신 `schtasks.exe` + `wsl.exe`를 사용하여 Windows 작업 스케줄러에 직접 등록
- `_is_wsl()`, `_get_wsl_distro_name()`, `_get_platform()` 헬퍼 함수 추가
- 플랫폼 감지를 2-way(`Windows`/`Linux`)에서 3-way(`windows`/`wsl`/`unix`)로 확장

## Changes
- **WSL 분기 추가**: `schtasks.exe /Create ... /TR "wsl.exe -d {distro} -- bash -c '...'"` 형태로 등록
- **Unix cmd_str 개선**: `cd '{cwd}'` 단일 인용부호로 공백 포함 경로 처리
- **에러 처리 강화**: `FileNotFoundError` 추가 캐치 → WSL interop 비활성화 안내 메시지
- **`_get_win_schedule_info()`**: `schtasks_cmd` 파라미터 추가 (WSL: `schtasks.exe`)
- **버전**: 1.3.1 → 1.3.2

## Test plan
- [ ] WSL에서 `claw-log --schedule 23:30` → schtasks.exe로 등록되는지 확인
- [ ] `claw-log --schedule-show` → schtasks.exe 쿼리 결과 표시
- [ ] `claw-log --status` → 등록 시각 표시
- [ ] `claw-log --schedule-remove` → schtasks.exe로 삭제
- [ ] 네이티브 Linux에서 기존 crontab 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)