### PR TITLE
fix(scheduler): WSL schtasks.exe 쿼리 인코딩 오류 수정 (v1.3.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claw-log-sh"
-version = "1.3.2"
+version = "1.3.3"
 description = "Automated Career Log using generative AI and Git diffs (fork of claw-log, original by Kim Woohyuck)"
 readme = "README.md"
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -63,11 +63,17 @@ def _get_win_schedule_info(schtasks_cmd="schtasks"):
     try:
         result = subprocess.run(
             [schtasks_cmd, "/Query", "/TN", WIN_TASK_NAME, "/FO", "LIST", "/V"],
-            capture_output=True, text=True
+            capture_output=True
         )
         if result.returncode != 0:
             return None
-        return result.stdout
+        # WSL에서 schtasks.exe 출력은 Windows ANSI 인코딩(cp949)일 수 있음
+        for enc in ('utf-8', 'cp949', 'euc-kr'):
+            try:
+                return result.stdout.decode(enc)
+            except UnicodeDecodeError:
+                continue
+        return result.stdout.decode('utf-8', errors='replace')
     except Exception:
         return None
 


### PR DESCRIPTION
## Problem
WSL에서 `--schedule-show` 실행 시 "등록된 스케줄이 없습니다" 출력.
`schtasks.exe` 쿼리 결과가 Windows ANSI(CP949)로 인코딩되어 있어
`text=True` + UTF-8 디코딩 시도 → `UnicodeDecodeError` → `except Exception: return None`.

## Fix
- `capture_output=True, text=True` → `capture_output=True` (bytes)
- `utf-8 → cp949 → euc-kr` 순서로 디코딩 시도, 모두 실패 시 `errors='replace'` 폴백

## Version
1.3.2 → 1.3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)