### PR TITLE
fix(scheduler): XML 인코딩 선언 불일치 수정 (v1.4.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claw-log-sh"
-version = "1.4.0"
+version = "1.4.1"
 description = "Automated Career Log using generative AI and Git diffs (fork of claw-log, original by Kim Woohyuck)"
 readme = "README.md"
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -88,7 +88,7 @@ def _build_task_xml(*, command, arguments, hour, minute):
     except AttributeError:
         pass  # Python < 3.9
 
-    return ET.tostring(root, encoding="unicode", xml_declaration=True)
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
 
 
 def _write_xml_to_temp(xml_str):


### PR DESCRIPTION
## Problem

v1.4.0에서 `claw-log --schedule` 실행 시 schtasks.exe가 아래 오류 반환:

```
오류: 작업 XML의 형식이 잘못되었습니다.
(1,40)::오류: 인코딩을 전환할 수 없습니다.
```

## Root Cause

`ET.tostring(encoding="unicode", xml_declaration=True)`가 XML 선언을 `encoding='us-ascii'`로 생성하지만, 파일은 UTF-8로 기록되어 schtasks.exe XML 파서가 불일치 감지.

## Fix

`xml_declaration=True` 제거 후 `<?xml version="1.0" encoding="UTF-8"?>` 헤더를 직접 prepend.

## Test plan

- [ ] `claw-log --schedule 23:30` → 오류 없이 등록 완료 확인
- [ ] PowerShell `schtasks /Query /TN ClawLog_Daily /FO LIST /V` 정상 조회 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)