### PR TITLE
fix(scheduler): XML 파일 인코딩 UTF-8→UTF-16 LE 수정 (v1.4.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claw-log-sh"
-version = "1.4.1"
+version = "1.4.2"
 description = "Automated Career Log using generative AI and Git diffs (fork of claw-log, original by Kim Woohyuck)"
 readme = "README.md"
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -88,14 +88,16 @@ def _build_task_xml(*, command, arguments, hour, minute):
     except AttributeError:
         pass  # Python < 3.9
 
-    return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
+    return ET.tostring(root, encoding="unicode")
 
 
 def _write_xml_to_temp(xml_str):
     """XML 문자열을 임시 파일에 쓰고 파일 경로를 반환합니다."""
     fd, path = tempfile.mkstemp(suffix=".xml", prefix="clawlog_")
     try:
-        os.write(fd, xml_str.encode("utf-8"))
+        # schtasks.exe는 UTF-16 LE + BOM 형식 XML을 요구함
+        # Python의 utf-16 코덱은 BOM(\xff\xfe)을 자동으로 prepend
+        os.write(fd, xml_str.encode("utf-16"))
     finally:
         os.close(fd)
     return path


### PR DESCRIPTION
## Problem

v1.4.1에서도 동일 오류 지속:
```
오류: 작업 XML의 형식이 잘못되었습니다.
(1,40)::오류: 인코딩을 전환할 수 없습니다.
```

## Root Cause

`schtasks.exe`가 기대하는 XML 형식은 **UTF-16 LE + BOM**이다.  
v1.4.1에서 XML 선언을 `encoding="UTF-8"`로 수정했지만, Windows XML 파서(MSXML)가 UTF-8 파일 자체를 거부한다.

## Fix

- XML 선언 헤더 제거 (BOM이 인코딩을 명시)
- `xml_str.encode("utf-8")` → `xml_str.encode("utf-16")`  
  Python의 `utf-16` 코덱은 자동으로 BOM(`\xff\xfe`) 을 prepend

## Verification

```python
>>> xml_str.encode("utf-16")[:2].hex()
'fffe'  # UTF-16 LE BOM 정상 확인
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)