### PR TITLE
fix+feat: API 에러 시 커밋 누락 방지 및 복구 시 누락 기간 자동 병합 (#35)

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,9 +13,15 @@ except (ImportError, PackageNotFoundError):
     __version__ = "unknown"
 
 from claw_log.engine import GeminiSummarizer, OpenAISummarizer, CodexOAuthSummarizer
-from claw_log.storage import prepend_to_log_file, read_recent_logs, save_log, parse_all_log_entries, LOG_FILENAME, LOG_FILE
+from claw_log.storage import (
+    prepend_to_log_file, read_recent_logs, save_log, parse_all_log_entries,
+    LOG_FILENAME, LOG_FILE, remove_error_log_entries,
+)
 from claw_log.scheduler import install_schedule, show_schedule, remove_schedule, get_schedule_summary
-from claw_log.state import load_state, save_state, get_last_hash, acquire_run_lock, release_run_lock
+from claw_log.state import (
+    load_state, save_state, get_last_hash, acquire_run_lock, release_run_lock,
+    save_failure_since, get_failure_since, clear_failure_since,
+)
 from claw_log.git_collector import (
     get_repo_key, get_latest_commit_hash, collect_project_commits,
     CommitData, ProjectCommits, PER_COMMIT_DIFF_LIMIT,
@@ -752,6 +758,10 @@ def _flush_batch(batch_text, batch_commits, summarizer, days, batch_idx):
     )
     if not summary or any(p in summary for p in _ERROR_PREFIXES):
         print(f"  {batch_label} 요약 실패: {summary}")
+        # days==0 모드에서만 실패 시작 날짜 추적 (--days N은 수동 실행이므로 제외)
+        if days == 0:
+            today_str = datetime.date.today().strftime("%Y-%m-%d")
+            save_failure_since(today_str)
         return (False, "")
 
     # 점진적 상태 저장 (days==0일 때만)
@@ -777,6 +787,7 @@ def run_batched_summarization(target_paths, summarizer, days):
         성공 시 True, 실패 시 False
     """
     state = load_state()
+    failure_since = get_failure_since(state) if days == 0 else None
 
     # 1. 모든 프로젝트의 커밋 데이터 수집
     all_projects = []
@@ -861,17 +872,36 @@ def run_batched_summarization(target_paths, summarizer, days):
 
     # 3. 모든 요약을 합쳐서 로그에 저장
     if all_summaries:
-        _save_all_summaries(all_summaries, days)
+        # 누락 기간 복구: failure_since가 있으면 날짜 범위 라벨 생성
+        date_label_override = None
+        if failure_since:
+            today_str = datetime.date.today().strftime("%Y-%m-%d")
+            if failure_since != today_str:
+                date_label_override = f"{failure_since} ~ {today_str}"
+            # 기존 에러 엔트리 제거 및 failure_since 초기화
+            removed = remove_error_log_entries()
+            if removed > 0:
+                print(f"  🗑️  에러 로그 {removed}개 정리 완료")
+            clear_failure_since()
+
+        _save_all_summaries(all_summaries, days, date_label_override=date_label_override)
         combined = "\n\n".join(all_summaries)
         print(f"\n" + "=" * 60 + f"\n{combined}\n" + "=" * 60)
 
     return True
 
 
-def _save_all_summaries(summaries, days):
-    """모든 배치 요약을 합쳐서 저장 (Notion + 로컬)."""
+def _save_all_summaries(summaries, days, date_label_override=None):
+    """모든 배치 요약을 합쳐서 저장 (Notion + 로컬).
+
+    Args:
+        date_label_override: 에러 복구 시 누락 기간을 표현하는 날짜 범위 (예: "2026-03-13 ~ 2026-03-18").
+                             지정 시 days 기반 라벨보다 우선 적용.
+    """
     combined = "\n\n".join(summaries)
-    if days > 0:
+    if date_label_override:
+        date_label = date_label_override
+    elif days > 0:
         start_date = (datetime.date.today() - datetime.timedelta(days=days)).strftime("%Y-%m-%d")
         end_date = datetime.date.today().strftime("%Y-%m-%d")
         date_label = f"{start_date} ~ {end_date}"

--- a/state.py
+++ b/state.py
@@ -64,6 +64,49 @@ def get_last_hash(state, repo_key):
     return entry["last_commit_hash"] if entry else None
 
 
+def save_failure_since(date_str):
+    """AI 요약 실패 시작 날짜를 state에 기록 (이미 있으면 덮어쓰지 않음).
+
+    Args:
+        date_str: 실패 시작 날짜 (YYYY-MM-DD)
+    """
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    current = load_state()
+    if "failure_since" not in current:
+        current["failure_since"] = date_str
+        tmp_path = STATE_FILE.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(current, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(str(tmp_path), str(STATE_FILE))
+
+
+def get_failure_since(state):
+    """state에서 failure_since 날짜 반환. 없으면 None.
+
+    Args:
+        state: load_state()로 로드한 state dict
+    Returns:
+        str | None — 실패 시작 날짜 (YYYY-MM-DD) 또는 None
+    """
+    return state.get("failure_since")
+
+
+def clear_failure_since():
+    """state에서 failure_since를 제거 (복구 완료 후 호출)."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    current = load_state()
+    if "failure_since" in current:
+        del current["failure_since"]
+        tmp_path = STATE_FILE.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(current, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(str(tmp_path), str(STATE_FILE))
+
+
 def acquire_run_lock():
     """단일 인스턴스 보장. 이미 실행 중이면 에러 메시지 반환, 성공 시 None 반환."""
     STATE_DIR.mkdir(parents=True, exist_ok=True)

--- a/storage.py
+++ b/storage.py
@@ -136,6 +136,52 @@ def read_recent_logs(n=5, filename=LOG_FILENAME):
     return entries[:n], None
 
 
+_ERROR_LOG_PATTERNS = (
+    "[Quota Error]", "[API Key Error]", "[OAuth Error]",
+    "[API Error]", "[Network Error]", "[Unknown Error]", "[Model Error]",
+)
+
+
+def remove_error_log_entries(filename=LOG_FILENAME):
+    """career_logs.md에서 에러 메시지만 담긴 엔트리를 제거합니다.
+
+    에러 패턴(_ERROR_LOG_PATTERNS)이 포함된 엔트리를 찾아 제거하며,
+    나머지 정상 엔트리는 유지합니다.
+
+    Returns:
+        int — 제거된 엔트리 수
+    """
+    file_path = LOG_FILE
+    if not file_path.exists():
+        return 0
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except Exception:
+        return 0
+
+    parts = re.split(r"(?=^## 📅 )", content, flags=re.MULTILINE)
+    kept = []
+    removed = 0
+    for part in parts:
+        if not part.strip():
+            continue
+        if any(p in part for p in _ERROR_LOG_PATTERNS):
+            removed += 1
+        else:
+            kept.append(part)
+
+    if removed > 0:
+        try:
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write("".join(kept))
+        except Exception:
+            return 0
+
+    return removed
+
+
 def prepend_to_log_file(summary, filename=LOG_FILENAME, date_label=None):
     """
     로그 파일 최상단에 새로운 로그를 추가합니다. (최신순)


### PR DESCRIPTION
## Summary

### 문제
- _flush_batch()의 에러 감지 로직이 구버전 접두사를 체크해 모든 에러가 성공으로 오인 → save_state() 호출 → 커밋 해시 advance → 해당 날짜 커밋 영구 누락

### 해결 (2 커밋)

#### Commit 1: 에러 감지 로직 수정
- 하드코딩된 "Gemini 요약 생성 실패", "OpenAI 요약 생성 실패" 감지 → 실제 에러 패턴 [Quota Error], [API Key Error] 등으로 교체
- 에러 시 save_state() 미호출 → 커밋 state 미advance

#### Commit 2: 누락 기간 복구 & 에러 로그 정리
- **state.py**: failure_since 필드 추가
  - 에러 발생 시 최초 실패 날짜를 state에 기록
  - 복구 성공 시 초기화
- **storage.py**: remove_error_log_entries() 추가
  - career_logs.md에서 에러 패턴 포함 엔트리 자동 제거
- **main.py**:
  - 에러 발생 시 save_failure_since(today) 호출
  - 복구 성공 시 누락 기간 날짜 범위 라벨 자동 생성 (예: 2026-03-13 ~ 2026-03-18)
  - 기존 에러 엔트리 자동 정리 후 새 로그 저장

### 시나리오
```
03/13~03/17: Quota 초과 → state 미advance, failure_since = "2026-03-13"
03/18: 사용량 충전 → claw-log 실행
       → 03/13 이후 모든 커밋 수집
       → 기존 에러 엔트리 제거 (있다면)
       → 로그 저장: ## 📅 2026-03-13 ~ 2026-03-18
       → failure_since 초기화
```

## Test plan
- [ ] Quota 에러 발생 → failure_since 기록, state hash 미advance 확인
- [ ] 복구 후 재실행 → 누락 기간 커밋 수집, 날짜 범위 라벨 로그 생성 확인
- [ ] 에러 엔트리 존재 시 자동 정리 확인
- [ ] --days N 모드에서는 failure_since 영향 없음 확인

Closes #35

🤖 Generated with Claude Code