### PR TITLE
fix: Windows --update WinError 32 오류 처리 (#21)

### DIFF
--- a/main.py
+++ b/main.py
@@ -942,6 +942,14 @@ def check_and_update():
     confirm = safe_input("   업데이트할까요? (y/n): ", "n").strip().lower()
     if confirm == "y":
         print("📦 업데이트 중...")
+        if sys.platform == "win32":
+            # Windows에서는 실행 중인 .exe를 pip이 교체할 수 없으므로 (WinError 32)
+            # 새 터미널에서 직접 실행하도록 안내
+            print("⚠️  Windows에서는 실행 중인 프로세스를 자동 업데이트할 수 없습니다.")
+            print("   새 터미널(cmd/PowerShell)을 열고 아래 명령어를 실행해주세요:")
+            print()
+            print("   pip install --upgrade claw-log-sh")
+            return
         result = subprocess.run(
             [sys.executable, "-m", "pip", "install", "--upgrade", "claw-log-sh"]
         )


### PR DESCRIPTION
## Summary

- Windows에서 `claw-log --update` 실행 시 실행 중인 `.exe` 파일을 pip이 교체할 수 없어 발생하는 WinError 32 해결
- `sys.platform == "win32"` 감지 후 자동 업데이트 시도 대신, 새 터미널에서 직접 실행할 명령어 안내로 변경
- Unix/macOS는 기존 자동 업데이트 동작 유지

## Why this approach

subprocess detach(`Popen + sys.exit()`) 방식도 고려했으나, Windows에서 프로세스 종료 타이밍과 파일 잠금 해제 사이의 경쟁 조건이 발생할 수 있어 신뢰성이 낮음. 명시적인 사용자 안내가 더 안정적이고 UX도 명확함.

## Test plan

- [ ] Windows에서 `claw-log --update` 실행 → WinError 없이 안내 메시지 출력 확인
- [ ] Linux/macOS에서 `claw-log --update` 실행 → 기존 pip upgrade 동작 유지 확인

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)